### PR TITLE
Fixed an issue with the 500 error code on the Streams listing page

### DIFF
--- a/backend/internal/stream.js
+++ b/backend/internal/stream.js
@@ -369,7 +369,7 @@ const internalStream = {
 					.where('is_deleted', 0)
 					.groupBy('id')
 					.allowGraph('[owner,certificate]')
-					.orderByRaw('CAST(incoming_port AS INTEGER) ASC');
+					.orderBy('incoming_port', 'ASC');
 
 				if (access_data.permission_visibility !== 'all') {
 					query.andWhere('owner_user_id', access.token.getUserId(1));


### PR DESCRIPTION
Fixed an issue with the 500 error code on the Streams listing page.
- Since incoming_port is a numeric type stored in the database, it does not need a case when sorting.

close: #4302